### PR TITLE
README: Add packaging status for cargo-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If you've used [nodemon], [guard], or [entr], it will probably feel familiar.
 
 ## Install
 
+<a href="https://repology.org/project/cargo-watch/versions"><img align="right" src="https://repology.org/badge/vertical-allrepos/cargo-watch.svg" alt="Packaging status"></a>
+
 Pre-built binaries are available **[from the website][cw-downloads]** or
 alternatively [on the Github Releases tab][releases]. Since 7.8.0, checksums and
 signatures are also provided; see [download documentation][downloads] for details.


### PR DESCRIPTION
Currently looks like this:

![](https://repology.org/badge/vertical-allrepos/cargo-watch.svg)