### PR TITLE
POC: ask 'cargo metadata' to tell us where the Cargo.toml manifests are

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-watch"
 version = "8.1.2"
 dependencies = [
@@ -247,6 +265,8 @@ dependencies = [
  "dunce",
  "embed-resource",
  "futures",
+ "guppy",
+ "home",
  "insta",
  "miette",
  "mimalloc",
@@ -261,12 +281,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edae0b9625d1fce32f7d64b71784d9b1bf8469ec1a9c417e44aaf16a9cbd7571"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -459,6 +502,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
 ]
+
+[[package]]
+name = "debug-ignore"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223089cd5a4e4491f0a0dddd9933f9575123160cf96ca2bb56a690046ecf1745"
 
 [[package]]
 name = "derivative"
@@ -814,6 +863,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "guppy"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2086fdcefd1a3dc6f4ba4568147648231e2211be1fcc4d1063601c6baadd2e"
+dependencies = [
+ "camino",
+ "cargo_metadata",
+ "cfg-if 1.0.0",
+ "debug-ignore",
+ "fixedbitset",
+ "guppy-workspace-hack",
+ "indexmap",
+ "itertools",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph",
+ "semver",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "target-spec",
+]
+
+[[package]]
+name = "guppy-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
+
+[[package]]
 name = "h2"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +953,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1304,6 +1393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
 name = "nix"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1609,15 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+dependencies = [
+ "camino",
 ]
 
 [[package]]
@@ -1991,6 +2095,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -2172,6 +2285,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+
+[[package]]
+name = "target-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc03d14ed79a75163d3509ebf1970a2ec67945c5cac68d947d1dddace43cec0"
+dependencies = [
+ "cfg-expr",
+ "target-lexicon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tracing = "0.1.26"
 watchexec = "2.0.0-pre.6"
 wild = "2.0.4"
 argfile = "0.1.3"
+guppy = "0.12.6"
+home = "0.5.3"
 
 [dependencies.clap]
 version = "3.0.10"

--- a/src/args.rs
+++ b/src/args.rs
@@ -165,6 +165,17 @@ pub struct Args {
 	)]
 	pub packages_specs: Vec<String>,
 
+	/// Don't ask `cargo metadata` which paths to watch for the current workspace
+	///
+	/// Implied by `-w`. Use `--no-metadata` or `-w .` if you have dependencies that are
+	/// not part of a cargo package, or if your cargo workspace is too big, and you don't
+	/// want to watch the whole thing.
+	#[clap(
+		long = "no-metadata",
+		help_heading = OPTSET_WORKSPACES
+	)]
+	pub no_metadata: bool,
+
 	/// Watch specific file(s) or folder(s)
 	///
 	/// By default, the entire crate/workspace is watched.


### PR DESCRIPTION
This is a first pass attempt at solving this problem. I'm not expecting this to be the shape that we land this in.

This goes some way to solving #117, and it might be possible to implement a --package (as described in https://github.com/watchexec/cargo-watch/issues/52#issuecomment-290107664 ) using a "walk the dependency tree looking for local packages" approach similar to this.

I decided to use `guppy` for parsing the dependency tree rather than `cargo_metadata`, because I wanted to see what it was like. I can port it to `cargo_metadata` or do the parsing via serde if you would prefer.

I decided against attempting to parse Cargo.toml and .cargo/config files directly. `cargo-chef` does this, and needed to do a bit of whack-a-mole before they covered all of the cases they cared about. If we decided to do this, we could use their work as a start, but we would need to add support for following .cargo/config files up to the root of $HOME. It would be more performant than my approach, but probably more fragile.

## Things that work

1) `cargo watch` will now follow path expressions, including patches, like:
```toml
[patch.crates-io]
xxx = {path = "../xxx"}
```
Note that doing this for watchexec didn't work for me after checking out both main branches. If `cargo check` gives you a message like:
 ```
warning: Patch `watchexec v2.0.0-pre.9 (/Users/alsuren/src/watchexec/lib)` was not used in the crate graph.
```
then we won't watch it.

2) If you run cargo watch from a dir that isn't the root of a workspace, it will watch all packages in the workspace for changes

## Things that don't work (and probably want addressing before merging):


- [ ] a) We don't attempt to re-run `cargo metadata` when Cargo.toml or .cargo/config files change.


- [ ] b) If you have a workspace root directory that contains a few rust packages and a few non-rust packages, running `cargo watch` in the root of the repo will now only watch directories that have Cargo.toml files in, and are part of the workspace. We don't watch the root of the workspace, so we will miss changes to your non-rust folders. It might be that we should default to also watching . even if we have metadata information?


- [ ] c) I currently just unwrap all errors. I haven't decided what to do with any of these errors.


- [ ] d) I have not added any tests. We probably want at least a test fixture with a workspace in it, and a fixture for a [patch.crates-io]?


- [ ] e) I'm not convinced that we want to turn this feature on by default as soon as it is merged, because there are a lot of hidden ways that it might misbehave. Might be worth making a flag called --metadata, and leaving it off by default until we're happy with it, before switching to the --no-metadata approach.


- [ ] f) I arbitrarily decided to exclude everything that's part of $CARGO_HOME. If someone manages to move the registry src cache (normally lives at $HOME/.cargo/registry/src) to a place that's outside $CARGO_HOME then we will end up watching the entire dependency tree, which would be quite expensive.

What do people think of this approach? Does it seem like it is worth pursuing, or should we switch to a different approach?