### PR TITLE
Automatically find workspaces of all local dependencies and watch them.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,21 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cargo-watch"
@@ -146,6 +158,7 @@ version = "8.1.2"
 dependencies = [
  "assert_cmd",
  "camino",
+ "cargo_metadata",
  "clap",
  "insta",
  "log",
@@ -155,6 +168,20 @@ dependencies = [
  "stderrlog",
  "wait-timeout",
  "watchexec",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -749,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "kernel32-sys"
@@ -1162,11 +1189,11 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1322,19 +1349,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
-name = "serde"
-version = "1.0.130"
+name = "semver"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1343,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -1463,13 +1499,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1521,18 +1557,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1568,6 +1604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,12 +1620,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ name = "cargo-watch"
 
 [dependencies]
 camino = "1.0.4"
+cargo_metadata = "0.15.1"
 clap = "2.33.1"
 log = "0.4.14"
 shell-escape = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -94,49 +94,39 @@ FLAGS:
         --no-gitignore       Don’t use .gitignore files
         --no-ignore          Don’t use .ignore files
         --no-restart         Don’t restart command while it’s still running
+    -N, --notify             Send a desktop notification when watchexec notices a change
+                             (experimental, behaviour may change)
         --poll               Force use of polling for file changes
         --postpone           Postpone first run until a file changes
+        --skip-local-deps    Don't try to find local dependencies of the current crate and watch
+                             their working directories. Only watch the current directory.
     -V, --version            Display version information
-        --watch-when-idle    Ignore events emitted while the commands run.
-                             Will become default behaviour in 8.0.
+        --watch-when-idle    Ignore events emitted while the commands run. Will become default
+                             behaviour in 8.0.
 
 OPTIONS:
-    -x, --exec <cmd>...
-            Cargo command(s) to execute on changes [default: check]
-
+    -x, --exec <cmd>...            Cargo command(s) to execute on changes [default: check]
     -s, --shell <cmd>...           Shell command(s) to execute on changes
-
-    -d, --delay <delay>
-            File updates debounce delay in seconds [default: 0.5]
-
-        --features <features>
-            List of features passed to cargo invocations
-
+    -d, --delay <delay>            File updates debounce delay in seconds [default: 0.5]
+        --features <features>      List of features passed to cargo invocations
     -i, --ignore <pattern>...      Ignore a glob/gitignore-style pattern
-
-    -B <rust-backtrace>
-            Inject RUST_BACKTRACE=VALUE (generally you want to set it to 1)
-            into the environment
-
-        --use-shell <use-shell>
-            Use a different shell. E.g. --use-shell=bash. On Windows, try
-            --use-shell=powershell, which will become the default in 8.0.
-
-    -w, --watch <watch>...
-            Watch specific file(s) or folder(s) [default: .]
-
-    -C, --workdir <workdir>
-            Change working directory before running command [default: crate root]
+    -B <rust-backtrace>            Inject RUST_BACKTRACE=VALUE (generally you want to set it to 1)
+                                   into the environment
+        --use-shell <use-shell>    Use a different shell. E.g. --use-shell=bash
+    -w, --watch <watch>...         Watch specific file(s) or folder(s). Disables finding and
+                                   watching local dependencies.
+    -C, --workdir <workdir>        Change working directory before running command [default: crate
+                                   root]
 
 ARGS:
     <cmd:trail>...    Full command to run. -x and -s will be ignored!
 
-Cargo commands (-x) are always executed before shell commands (-s). You can use
-the `-- command` style instead, note you'll need to use full commands, it won't
-prefix `cargo` for you.
+Cargo commands (-x) are always executed before shell commands (-s). You can use the `-- command`
+style instead, note you'll need to use full commands, it won't prefix `cargo` for you.
 
-By default, your entire project is watched, except for the target/ and .git/
-folders, and your .ignore and .gitignore files are used to filter paths.
+By default, the workspace directories of your project and all local dependencies are watched,
+except for the target/ and .git/ folders. Your .ignore and .gitignore files are used to filter
+paths.
 
 On Windows, patterns given to -i have forward slashes (/) automatically
 converted to backward ones (\) to ease command portability.

--- a/cargo-watch.1
+++ b/cargo-watch.1
@@ -57,11 +57,15 @@ Show paths that changed\.
 Suppress output from cargo\-watch itself\.
 .
 .TP
+\fB\-\-skip\-local\-deps\fR
+Don't try to find local dependencies of the current crate and watch their working directories\. Only watch the current directory\.
+.
+.TP
 \fB\-w\fR, \fB\-\-watch\fR \fIwatch\fR\.\.\.
-Watch specific file(s) or folder(s)\.
+Watch specific file(s) or folder(s)\. Disables finding and watching local dependencies\.
 .
 .P
-By default, your entire project is watched, except for the target/ and \.git/ folders, and your \.ignore and \.gitignore files are used to filter paths\.
+By default, the workspace directories of your project and all local dependencies are watched, except for the target/ and \.git/ folders\. Your \.ignore and \.gitignore files are used to filter paths\.
 .
 .TP
 \fB\-i\fR, \fB\-\-ignore\fR \fIpattern\fR\.\.\.

--- a/cargo-watch.1.ronn
+++ b/cargo-watch.1.ronn
@@ -42,10 +42,13 @@ Show paths that changed.
 * `-q`, `--quiet`:
 Suppress output from cargo-watch itself.
 
-* `-w`, `--watch` <watch>...:
-Watch specific file(s) or folder(s).
+* `--skip-local-deps`:
+Don't try to find local dependencies of the current crate and watch their working directories. Only watch the current directory.
 
-By default, your entire project is watched, except for the target/ and .git/ folders, and your .ignore and .gitignore files are used to filter paths.
+* `-w`, `--watch` <watch>...:
+Watch specific file(s) or folder(s). Disables finding and watching local dependencies.
+
+By default, the workspace directories of your project and all local dependencies are watched, except for the target/ and .git/ folders. Your .ignore and .gitignore files are used to filter paths.
 
 * `-i`, `--ignore` <pattern>...:
 Ignore a glob/gitignore-style pattern.

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,7 +2,7 @@ use clap::{App, AppSettings, Arg, ArgMatches, ErrorKind, SubCommand};
 use std::{env, process};
 
 pub fn parse() -> ArgMatches<'static> {
-    let footnote = "Cargo commands (-x) are always executed before shell commands (-s). You can use the `-- command` style instead, note you'll need to use full commands, it won't prefix `cargo` for you.\n\nBy default, your entire project is watched, except for the target/ and .git/ folders, and your .ignore and .gitignore files are used to filter paths.".to_owned();
+    let footnote = "Cargo commands (-x) are always executed before shell commands (-s). You can use the `-- command` style instead, note you'll need to use full commands, it won't prefix `cargo` for you.\n\nBy default, the workspace directories of your project and all local dependencies are watched, except for the target/ and .git/ folders. Your .ignore and .gitignore files are used to filter paths.".to_owned();
 
     #[cfg(windows)] let footnote = format!("{}\n\nOn Windows, patterns given to -i have forward slashes (/) automatically converted to backward ones (\\) to ease command portability.", footnote);
 
@@ -166,8 +166,7 @@ pub fn parse() -> ArgMatches<'static> {
                         .empty_values(false)
                         .min_values(1)
                         .number_of_values(1)
-                        .default_value(".")
-                        .help("Watch specific file(s) or folder(s)"),
+                        .help("Watch specific file(s) or folder(s). Disables finding and watching local dependencies."),
                 )
                 .arg(
                     Arg::with_name("use-shell")
@@ -203,6 +202,11 @@ pub fn parse() -> ArgMatches<'static> {
                     Arg::with_name("cmd:trail")
                         .raw(true)
                         .help("Full command to run. -x and -s will be ignored!"),
+                )
+                .arg(
+                    Arg::with_name("skip-local-deps")
+                    .help("Don't try to find local dependencies of the current crate and watch their working directories. Only watch the current directory.")
+                    .long("skip-local-deps")
                 )
                 .after_help(footnote.as_str()),
         );


### PR DESCRIPTION
This watches the workspace roots of all dependencies which are local, plus the workspace root of the current project. This has no effect if --watch/-w is manually specified.

Fixes #117.

It's very possible I'm missing some nuances though! Maybe this breaks in certain constellations of where cargo is invoked? Please let me know if I'm missing something.