### PR TITLE
Build -gnu targets on ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           - windows-arm64
         include:
           - name: linux-x86-64-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             cross: false
             experimental: false
@@ -33,13 +33,13 @@ jobs:
             experimental: false
 
           - name: linux-armhf-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             target: armv7-unknown-linux-gnueabihf
             cross: true
             experimental: false
 
           - name: linux-arm64-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             cross: true
             experimental: false


### PR DESCRIPTION
This happens to be similar to cargo-bins/cargo-binstall#607; essentially, the ubuntu-latest workflow runner now points to ubuntu 22.04, which has a newer glibc version than e.g. Debian stable, so when you try to run the binaries built on it on Debian stable, you get errors like:

```
/usr/local/cargo/bin/cargo-watch: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /usr/local/cargo/bin/cargo-watch)
/usr/local/cargo/bin/cargo-watch: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/cargo/bin/cargo-watch)
/usr/local/cargo/bin/cargo-watch: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/cargo/bin/cargo-watch)
```

This fixes the issue by explicitly specifying 20.04, which has a lower version of glibc.
