### PR TITLE
Fix output formatting for windows

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -57,7 +57,7 @@ impl CwHandler {
                 #[cfg(unix)]
                 final_cmd.push_str(r#"; echo "[Finished running. Exit status: $?]""#);
                 #[cfg(windows)]
-                final_cmd.push_str(r#" & echo "[Finished running. Exit status: %ERRORLEVEL%]""#);
+                final_cmd.push_str(r#" & echo [Finished running. Exit status: %ERRORLEVEL%]"#);
                 #[cfg(not(any(unix, windows)))]
                 final_cmd.push_str(r#" ; echo "[Finished running]""#);
                 // ^ could be wrong depending on the platform, to be fixed on demand


### PR DESCRIPTION
I removed the unnecessary quoting which made the output `\"[Finished running. Exit status: 0]\"` instead of `[Finished running. Exit status: 0]` when running in cmd. This change doesn't effect the output in powershell.