### PR TITLE
Upgrade MSRV to Rust 1.69.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
           - macos
         toolchain:
           - stable
-          - 1.67.1
+          - 1.74.0
 
     name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
           - macos
         toolchain:
           - stable
-          - 1.74.0
+          - 1.69.0
 
     name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/watchexec/cargo-watch"
 readme = "README.md"
 
 edition = "2021"
-rust-version = "1.67.1"
+rust-version = "1.69.0"
 exclude = ["/.github"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you've used [nodemon], [guard], or [entr], it will probably feel familiar.
 [guard]: http://guardgem.org/
 
 - In the public domain / licensed with CC0.
-- Minimum Supported Rust Version: 1.67.1.
+- Minimum Supported Rust Version: 1.69.0.
   - Only the last five stable versions are supported.
   - MSRV increases beyond that range at publish time will not incur major version bumps.
 


### PR DESCRIPTION
The GH workflow check is [failing](https://github.com/watchexec/cargo-watch/actions/runs/6281252999/job/17059433927#step:6:32) with the following error.
```
error: package `predicates v3.0.4` cannot be built because it requires rustc 1.69.0 or newer, while the currently active rustc version is 1.67.1
```

This upgrades the MSRV for `cargo-watch` to Rust 1.69.0, which will allow `predicates v3.0.4` to build in CI.