### PR TITLE
Provide completion for cargo watch -x <TAB>

### DIFF
--- a/completions/zsh
+++ b/completions/zsh
@@ -12,7 +12,7 @@ args=(
   '(-c --clear)'{-c,--clear}'[Clear screen before executing command]'
   '(-h --help)'{-h,--help}'[Print help information]'
   '(-V --version)'{-V,--version}'[Print version information]'
-  '(-x --exec)'{-x+,--exec=}'[Cargo subcommand to execute on changes]:cargo-command'
+  '(-x --exec)'{-x+,--exec=}'[Cargo subcommand to execute on changes]:cargo-command:_cargo_cmds'
   '(-s --shell)'{-s+,--shell=}'[Shell command to execute on changes]:command'
   '(-i --ignore)'{-i+,--ignore=}'[Ignore changes to paths matching the pattern]:pattern'
   '(-w --watch)'{-w+,--watch=}'[Watch a specific directory]:path:_path_files -/'


### PR DESCRIPTION
Hereby I quickly added locally for me completion for `cargo watch -x <TAB>`. I haven't yet wrapped my head around more complex calls `cargo watch -x "build --rele<TAB>` and i so far blindly assume the `_cargo` file from rustup has been loaded by the completions system to provide _cargo_cmds. wdyt, is this worth having? (as is? differently?) also i noticed the repo looks different in the main branch but the 8.x branch looked more recent.