### PR TITLE
Add select support for '-x'-less cargo commands

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
           - macos
         toolchain:
           - stable
-          - 1.67.1
+          - 1.70.0
 
     name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/watchexec/cargo-watch"
 readme = "README.md"
 
 edition = "2021"
-rust-version = "1.67.1"
+rust-version = "1.70.0"
 exclude = ["/.github"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you've used [nodemon], [guard], or [entr], it will probably feel familiar.
 [guard]: http://guardgem.org/
 
 - In the public domain / licensed with CC0.
-- Minimum Supported Rust Version: 1.67.1.
+- Minimum Supported Rust Version: 1.70.0.
   - Only the last five stable versions are supported.
   - MSRV increases beyond that range at publish time will not incur major version bumps.
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -238,17 +238,33 @@ pub fn parse() -> ArgMatches<'static> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("cmd:trail")
-                        .raw(true)
-                        .help("Full command to run. -x and -s will be ignored!"),
-                )
-                .arg(
                     Arg::with_name("skip-local-deps")
                     .help("Don't try to find local dependencies of the current crate and watch their working directories. Only watch the current directory.")
                     .long("skip-local-deps")
                 )
+                .subcommand(special_cargo_subc("bench"))
+                .subcommand(special_cargo_subc("build"))
+                .subcommand(special_cargo_subc("check"))
+                .subcommand(special_cargo_subc("clippy"))
+                .subcommand(special_cargo_subc("test"))
+                .arg(
+                    Arg::with_name("cmd:trail")
+                        .raw(true)
+                        .help("Full command to run. -x and -s will be ignored!"),
+                )
                 .after_help(footnote.as_str()),
         );
+
+    fn special_cargo_subc(name: &str) -> App {
+        SubCommand::with_name(name)
+            .setting(AppSettings::AllowLeadingHyphen)
+            .setting(AppSettings::DisableHelpFlags)
+            .setting(AppSettings::DisableHelpSubcommand)
+            .setting(AppSettings::DisableVersion)
+            .setting(AppSettings::Hidden)
+            .setting(AppSettings::TrailingVarArg)
+            .arg(Arg::with_name("args").multiple(true))
+    }
 
     // Allow invocation of cargo-watch with both `cargo-watch watch ARGS`
     // (as invoked by cargo) and `cargo-watch ARGS`.


### PR DESCRIPTION
Enables:

```console
$ cargo watch clippy --clippy --args
```

instead of having to use `-x 'clippy --clippy --args'` or specify `-- cargo clippy --clippy --args`.

Supported commands: `bench`, `build`, `check`, `clippy`, `test` only.