### PR TITLE
Filter to the host platform when running the default command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use watchexec::{error::Result, run::watch};
 mod args;
 mod options;
 mod root;
+mod rustc;
 mod watch;
 
 fn main() -> Result<()> {

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -1,0 +1,21 @@
+use clap::{Error, ErrorKind};
+use std::{io::BufRead, process::Command};
+
+/// Queries `rustc` to identify the host platform's target triple.
+pub fn host_triple() -> String {
+    Command::new("rustc")
+        .arg("-vV")
+        .output()
+        .map_err(|err| err.to_string())
+        .and_then(|out| {
+            // Look for a line starting with `host: `, just like `cargo` does, to identify the
+            // host platform -- see:
+            // https://github.com/rust-lang/cargo/blob/631b8774e512a69402a55367b4eb9c195220e404/src/cargo/util/rustc.rs#L68
+            out.stdout
+                .lines()
+                .map_while(Result::ok)
+                .find_map(|line| line.strip_prefix("host: ").map(ToString::to_string))
+                .ok_or_else(|| "`rustc -vV` didn't have a line for `host`.".to_string())
+        })
+        .unwrap_or_else(|err| Error::with_description(&err, ErrorKind::Io).exit())
+}


### PR DESCRIPTION
Fixes #312.

This uses the [same logic that `cargo` does](https://github.com/rust-lang/cargo/blob/631b8774e512a69402a55367b4eb9c195220e404/src/cargo/util/rustc.rs#L68) to identify the host platform, which unfortunately requires a call to `rustc`.

We invoke this logic if the user _did not provide_ any of their own commands in the invocation to `cargo watch` -- this is probably more conservative than it strictly needs to be. If the user invokes a `cargo` subcommand, for instance, we may know enough about the subcommand and its arguments to know that it's still possible to filter to the host platform. I avoided adding that additional complexity for now but it could easily be added in the future.
